### PR TITLE
Correct opentracing error setting

### DIFF
--- a/lib/DBIx/OpenTracing.pm
+++ b/lib/DBIx/OpenTracing.pm
@@ -370,7 +370,7 @@ sub _gen_wrapper {
         my $error = $@;
 
         if ($failed or defined $handle->err) {
-            $span->add_tag(error => 1);
+            $span->add_tags( generate_error_tags($handle, $failed) );
         }
         elsif ($can_count_rows->($handle)) {
             my $rows = sum0(map { $row_counter->($_) } $wantarray ? @$result : $result);
@@ -404,6 +404,24 @@ sub suspend {
     disable();
     $is_suspended = 1;
     Scope::Context->up->reap(sub { $is_suspended = 0; enable() if $was_enabled });
+}
+
+sub generate_error_tags {
+    my ($handle, $failed) = @_;
+    
+    my $error_message = sprintf ("DBI Error: SQLSTATE_%s - [%s]",
+        $handle->state || '-----',
+        $handle->err   || '-',
+    );
+    my $error_kind = sprintf("SQLSTATE_%s",
+        $handle->state || '-----',
+    );
+    
+    return (
+        'error'      => 1,
+        'message'    => $error_message,
+        'error.kind' => $error_kind,
+    );
 }
 
 1;

--- a/lib/DBIx/OpenTracing.pod
+++ b/lib/DBIx/OpenTracing.pod
@@ -59,6 +59,10 @@ L<OpenTracing conventions|https://opentracing.io/specification/conventions/>:
 
 =item * error - will be set to true if the query failed
 
+=item * error.kind - A string containing the C<I<SQLSTATE>>, for ex. "SQLSTATE_0700F"
+
+=item * message - A readable message indicating the kind of error (not the SQL-Statement)
+
 =back
 
 =head1 IMPORT ARGUMENTS

--- a/t/lib/Test/DBIx/OpenTracing.pm
+++ b/t/lib/Test/DBIx/OpenTracing.pm
@@ -29,8 +29,12 @@ sub test_database {
         maybe 'db.instance'    => $db_name,
         maybe 'db.user'        => $user,
     );
+    my %tag_errs = (
+              'error'           => 1,
+    );
+    
     span_generation_ok($dbh, $statements, {%tag_base});
-    error_detection_ok($dbh, $sql_invalid, {%tag_base});
+    error_detection_ok($dbh, $sql_invalid, {%tag_base}, {%tag_errs});
     enable_disable_ok($dbh, $sql_simple);
     compatibility_ok($dbh, $statements);
     tag_control_ok($dbh, $statements->{bind}, {%tag_base});
@@ -269,7 +273,7 @@ sub selectcol_ok {
 }
 
 sub error_detection_ok {
-    my ($dbh, $sql_invalid, $tag_base) = @_;
+    my ($dbh, $sql_invalid, $tag_base, $tag_errs) = @_;
 
     my @methods = qw(
         do
@@ -293,7 +297,7 @@ sub error_detection_ok {
                         %$tag_base,
                         'caller.subname' => _sub_here('__ANON__'),
                         'db.statement'   => $sql_invalid,
-                        error            => 1,
+						%$tag_errs,
                     },
                 }], "$method produces a span with correct tags");
             }

--- a/t/lib/Test/DBIx/OpenTracing.pm
+++ b/t/lib/Test/DBIx/OpenTracing.pm
@@ -20,6 +20,8 @@ sub test_database {
     my $sql_invalid = $statements->{invalid};
     my $sql_simple  = $statements->{simple};
     my $sql_clear   = $statements->{clear};
+    my $sql_state   = $args{error_detection}->{sqlstate};
+    my $sql_errcode = $args{error_detection}->{err};
 
     my %tag_base = (
               'caller.file'    => __FILE__,
@@ -31,6 +33,8 @@ sub test_database {
     );
     my %tag_errs = (
               'error'           => 1,
+              'message'         => re(qr/${sql_state}/),
+              'error.kind'      => "SQLSTATE_${sql_state}",
     );
     
     span_generation_ok($dbh, $statements, {%tag_base});

--- a/t/lib/Test/DBIx/OpenTracing.pm
+++ b/t/lib/Test/DBIx/OpenTracing.pm
@@ -24,12 +24,12 @@ sub test_database {
     my $sql_errcode = $args{error_detection}->{err};
 
     my %tag_base = (
-              'caller.file'    => __FILE__,
-              'caller.line'    => re(qr/\A\d+\z/),
-              'caller.package' => __PACKAGE__,
-              'db.type'        => 'sql',
-        maybe 'db.instance'    => $db_name,
-        maybe 'db.user'        => $user,
+              'caller.file'     => __FILE__,
+              'caller.line'     => re(qr/\A\d+\z/),
+              'caller.package'  => __PACKAGE__,
+              'db.type'         => 'sql',
+        maybe 'db.instance'     => $db_name,
+        maybe 'db.user'         => $user,
     );
     my %tag_errs = (
               'error'           => 1,
@@ -301,7 +301,7 @@ sub error_detection_ok {
                         %$tag_base,
                         'caller.subname' => _sub_here('__ANON__'),
                         'db.statement'   => $sql_invalid,
-						%$tag_errs,
+                        %$tag_errs,
                     },
                 }], "$method produces a span with correct tags");
             }

--- a/t/mem.t
+++ b/t/mem.t
@@ -36,5 +36,10 @@ Test::DBIx::OpenTracing::test_database(
         simple  => 'SELECT 1',
         bind => [ 'SELECT id, description FROM things WHERE id IN (?, ?)', 1, 3 ],
     },
+    error_detection => {
+        sqlstate    => 'S1000',
+        err         => '2000000000',
+    },
 );
+
 done_testing();

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -107,5 +107,10 @@ Test::DBIx::OpenTracing::test_database(
             ],
         ],
     },
+    error_detection => {
+        sqlstate    => '42000',
+        err         => '1064',
+    },
 );
+
 done_testing();

--- a/t/postgresql.t
+++ b/t/postgresql.t
@@ -43,5 +43,10 @@ Test::DBIx::OpenTracing::test_database(
         simple  => 'SELECT 1',
         bind => [ 'SELECT id, description FROM things WHERE id IN (?, ?)', 1, 3 ],
     },
+    error_detection => {
+        sqlstate    => '42601',
+        err         => '7',
+    },
 );
+
 done_testing();

--- a/t/sqlite.t
+++ b/t/sqlite.t
@@ -37,5 +37,10 @@ Test::DBIx::OpenTracing::test_database(
         simple  => 'SELECT 1',
         bind => [ 'SELECT id, description FROM things WHERE id IN (?, ?)', 1, 3 ],
     },
+    error_detection => {
+        sqlstate    => 'S1000',
+        err         => '1',
+    },
 );
+
 done_testing();


### PR DESCRIPTION
This will set `error.kind` and `message`.

A future version may change the strings though